### PR TITLE
Make Resp non-generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ github.com/orsinium-labs/josh
 Here is a simple handler:
 
 ```go
-func handler(r josh.Req) josh.Resp[string] {
+func handler(r josh.Req) josh.Resp {
   // Read JSON request body
-  msg, err := josh.Read[string](r)
+  msg, err := josh.Read(r)
   if err != nil {
     // Return an error for invalid request
-    return josh.BadRequest[string](josh.Error{
+    return josh.BadRequest(josh.Error{
       Title:  "Cannot parse JSON request",
       Detail: err.Error(),
     })

--- a/_examples/crud/crud.go
+++ b/_examples/crud/crud.go
@@ -40,11 +40,11 @@ type Post struct {
 var posts map[int]Post
 var nextId = 0
 
-func CreatePost(r josh.Req) josh.Resp[Post] {
+func CreatePost(r josh.Req) josh.Resp {
 	post, err := josh.Read[Post](r)
 	if err != nil {
 		respErr := josh.Error{Detail: err.Error()}
-		return josh.BadRequest[Post](respErr)
+		return josh.BadRequest(respErr)
 	}
 	post.ID = nextId
 	posts[nextId] = post
@@ -52,7 +52,7 @@ func CreatePost(r josh.Req) josh.Resp[Post] {
 	return josh.Created(post)
 }
 
-func ListPosts(r josh.Req) josh.Resp[[]Post] {
+func ListPosts(r josh.Req) josh.Resp {
 	list := make([]Post, 0)
 	for _, post := range posts {
 		list = append(list, post)
@@ -60,16 +60,16 @@ func ListPosts(r josh.Req) josh.Resp[[]Post] {
 	return josh.Ok(list)
 }
 
-func GetPost(r josh.Req) josh.Resp[Post] {
+func GetPost(r josh.Req) josh.Resp {
 	postId, err := strconv.Atoi(r.PathValue("id"))
 	if err != nil {
 		respErr := josh.Error{Detail: err.Error()}
-		return josh.BadRequest[Post](respErr)
+		return josh.BadRequest(respErr)
 	}
 	post, found := posts[postId]
 	if !found {
 		respErr := josh.Error{Detail: "post with the given ID does not exist"}
-		return josh.NotFound[Post](respErr)
+		return josh.NotFound(respErr)
 	}
 	return josh.Ok(post)
 }

--- a/_examples/crud/crud.go
+++ b/_examples/crud/crud.go
@@ -74,37 +74,37 @@ func GetPost(r josh.Req) josh.Resp[Post] {
 	return josh.Ok(post)
 }
 
-func UpdatePost(r josh.Req) josh.Void {
+func UpdatePost(r josh.Req) josh.Resp {
 	postId, err := strconv.Atoi(r.PathValue("id"))
 	if err != nil {
 		respErr := josh.Error{Detail: err.Error()}
-		return josh.BadRequest[josh.Z](respErr)
+		return josh.BadRequest(respErr)
 	}
 	oldPost, found := posts[postId]
 	if !found {
 		respErr := josh.Error{Detail: "post with the given ID does not exist"}
-		return josh.NotFound[josh.Z](respErr)
+		return josh.NotFound(respErr)
 	}
 	newPost, err := josh.Read[Post](r)
 	if err != nil {
 		respErr := josh.Error{Detail: err.Error()}
-		return josh.BadRequest[josh.Z](respErr)
+		return josh.BadRequest(respErr)
 	}
 	if newPost.Title != "" {
 		oldPost.Title = newPost.Title
 	}
 	posts[postId] = oldPost
-	return josh.NoContent[josh.Z]()
+	return josh.NoContent()
 }
 
-func DeletePost(r josh.Req) josh.Void {
+func DeletePost(r josh.Req) josh.Resp {
 	postId, err := strconv.Atoi(r.PathValue("id"))
 	if err != nil {
 		respErr := josh.Error{Detail: err.Error()}
-		return josh.BadRequest[josh.Z](respErr)
+		return josh.BadRequest(respErr)
 	}
 	delete(posts, postId)
-	return josh.NoContent[josh.Z]()
+	return josh.NoContent()
 }
 
 func main() {

--- a/_examples/echo/echo.go
+++ b/_examples/echo/echo.go
@@ -28,10 +28,10 @@ import (
 	"github.com/orsinium-labs/josh"
 )
 
-func handler(r josh.Req) josh.Resp[string] {
+func handler(r josh.Req) josh.Resp {
 	msg, err := josh.Read[string](r)
 	if err != nil {
-		return josh.BadRequest[string](josh.Error{
+		return josh.BadRequest(josh.Error{
 			Title:  "Cannot parse JSON request",
 			Detail: err.Error(),
 		})

--- a/constructors.go
+++ b/constructors.go
@@ -2,28 +2,36 @@ package josh
 
 import "github.com/orsinium-labs/josh/statuses"
 
+// Do not send any response.
+//
+// Return it from a handler when the handler handles sanding the response itself.
+// For example, when it establishes a WebSocket connection.
+func NoResponse() Resp {
+	return Resp{}
+}
+
 // Respond with 200 status code.
 //
 // https://jsonapi.org/format/#fetching-resources-responses-200
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
-func Ok[T any](v T) Resp[T] {
-	return Resp[T]{
+func Ok(v any) Resp {
+	return Resp{
 		Status: statuses.OK,
 		Data:   &v,
 	}
 }
 
 // Respond with 201 status code.
-func Created[T any](v T) Resp[T] {
-	return Resp[T]{
+func Created(v any) Resp {
+	return Resp{
 		Status: statuses.Created,
 		Data:   &v,
 	}
 }
 
 // Respond with 202 status code.
-func Accepted[T any](v T) Resp[T] {
-	return Resp[T]{
+func Accepted(v any) Resp {
+	return Resp{
 		Status: statuses.Accepted,
 		Data:   &v,
 	}
@@ -34,8 +42,8 @@ func Accepted[T any](v T) Resp[T] {
 // Indicates that there is no content to send for this request.
 //
 // The response does not have a body.
-func NoContent[T any]() Resp[T] {
-	return Resp[T]{
+func NoContent() Resp {
+	return Resp{
 		Status: statuses.NoContent,
 	}
 }
@@ -46,31 +54,31 @@ func NoContent[T any]() Resp[T] {
 // so the client can continue to use the same cached version of the response.
 //
 // The response does not have a body.
-func NotModified[T any]() Resp[T] {
-	return Resp[T]{
+func NotModified() Resp {
+	return Resp{
 		Status: statuses.NotModified,
 	}
 }
 
 // Respond with 400 status code.
-func BadRequest[T any](err Error) Resp[T] {
-	return Resp[T]{
+func BadRequest(err Error) Resp {
+	return Resp{
 		Status: statuses.BadRequest,
 		Errors: []Error{err},
 	}
 }
 
 // Respond with 401 status code.
-func Unauthorized[T any](err Error) Resp[T] {
-	return Resp[T]{
+func Unauthorized(err Error) Resp {
+	return Resp{
 		Status: statuses.Unauthorized,
 		Errors: []Error{err},
 	}
 }
 
 // Respond with 403 status code.
-func Forbidden[T any](err Error) Resp[T] {
-	return Resp[T]{
+func Forbidden(err Error) Resp {
+	return Resp{
 		Status: statuses.Forbidden,
 		Errors: []Error{err},
 	}
@@ -80,8 +88,8 @@ func Forbidden[T any](err Error) Resp[T] {
 //
 // https://jsonapi.org/format/#fetching-resources-responses-404
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-func NotFound[T any](err Error) Resp[T] {
-	return Resp[T]{
+func NotFound(err Error) Resp {
+	return Resp{
 		Status: statuses.NotFound,
 		Errors: []Error{err},
 	}
@@ -90,8 +98,8 @@ func NotFound[T any](err Error) Resp[T] {
 // Respond with 500 status code.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-func InternalServerError[T any](err Error) Resp[T] {
-	return Resp[T]{
+func InternalServerError(err Error) Resp {
+	return Resp{
 		Status: statuses.InternalServerError,
 		Errors: []Error{err},
 	}

--- a/constructors_test.go
+++ b/constructors_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestOk(t *testing.T) {
-	h := josh.Wrap(func(r josh.Req) josh.Resp[int] {
+	h := josh.Wrap(func(r josh.Req) josh.Resp {
 		return josh.Ok(13)
 	})
 	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
@@ -22,7 +22,7 @@ func TestOk(t *testing.T) {
 }
 
 func TestCreated(t *testing.T) {
-	h := josh.Wrap(func(r josh.Req) josh.Resp[int] {
+	h := josh.Wrap(func(r josh.Req) josh.Resp {
 		return josh.Created(13)
 	})
 	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
@@ -35,7 +35,7 @@ func TestCreated(t *testing.T) {
 }
 
 func TestAccepted(t *testing.T) {
-	h := josh.Wrap(func(r josh.Req) josh.Resp[int] {
+	h := josh.Wrap(func(r josh.Req) josh.Resp {
 		return josh.Accepted(13)
 	})
 	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
@@ -48,8 +48,8 @@ func TestAccepted(t *testing.T) {
 }
 
 func TestNoContent(t *testing.T) {
-	h := josh.Wrap(func(r josh.Req) josh.Void {
-		return josh.NoContent[josh.Z]()
+	h := josh.Wrap(func(r josh.Req) josh.Resp {
+		return josh.NoContent()
 	})
 	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
 	w := httptest.NewRecorder()
@@ -60,8 +60,8 @@ func TestNoContent(t *testing.T) {
 }
 
 func TestNotModified(t *testing.T) {
-	h := josh.Wrap(func(r josh.Req) josh.Void {
-		return josh.NotModified[josh.Z]()
+	h := josh.Wrap(func(r josh.Req) josh.Resp {
+		return josh.NotModified()
 	})
 	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
 	w := httptest.NewRecorder()
@@ -72,9 +72,9 @@ func TestNotModified(t *testing.T) {
 }
 
 func TestBadRequest(t *testing.T) {
-	h := josh.Wrap(func(r josh.Req) josh.Void {
+	h := josh.Wrap(func(r josh.Req) josh.Resp {
 		err := josh.Error{Detail: "oh no"}
-		return josh.BadRequest[josh.Z](err)
+		return josh.BadRequest(err)
 	})
 	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
 	w := httptest.NewRecorder()
@@ -86,9 +86,9 @@ func TestBadRequest(t *testing.T) {
 }
 
 func TestUnauthorized(t *testing.T) {
-	h := josh.Wrap(func(r josh.Req) josh.Void {
+	h := josh.Wrap(func(r josh.Req) josh.Resp {
 		err := josh.Error{Detail: "oh no"}
-		return josh.Unauthorized[josh.Z](err)
+		return josh.Unauthorized(err)
 	})
 	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
 	w := httptest.NewRecorder()
@@ -100,9 +100,9 @@ func TestUnauthorized(t *testing.T) {
 }
 
 func TestForbidden(t *testing.T) {
-	h := josh.Wrap(func(r josh.Req) josh.Void {
+	h := josh.Wrap(func(r josh.Req) josh.Resp {
 		err := josh.Error{Detail: "oh no"}
-		return josh.Forbidden[josh.Z](err)
+		return josh.Forbidden(err)
 	})
 	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
 	w := httptest.NewRecorder()
@@ -114,9 +114,9 @@ func TestForbidden(t *testing.T) {
 }
 
 func TestNotFound(t *testing.T) {
-	h := josh.Wrap(func(r josh.Req) josh.Void {
+	h := josh.Wrap(func(r josh.Req) josh.Resp {
 		err := josh.Error{Detail: "oh no"}
-		return josh.NotFound[josh.Z](err)
+		return josh.NotFound(err)
 	})
 	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
 	w := httptest.NewRecorder()
@@ -128,9 +128,9 @@ func TestNotFound(t *testing.T) {
 }
 
 func TestInternalServerError(t *testing.T) {
-	h := josh.Wrap(func(r josh.Req) josh.Void {
+	h := josh.Wrap(func(r josh.Req) josh.Resp {
 		err := josh.Error{Detail: "oh no"}
-		return josh.InternalServerError[josh.Z](err)
+		return josh.InternalServerError(err)
 	})
 	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
 	w := httptest.NewRecorder()

--- a/josh.go
+++ b/josh.go
@@ -67,13 +67,16 @@ func SetHeader(r Req, key headers.Header, value string) {
 
 // Read and parse request body as JSON.
 func Read[T any](r Req) (T, error) {
-	if r.ContentLength == 0 {
+	// TODO: improve based on this blog post:
+	// https://www.alexedwards.net/blog/how-to-properly-parse-a-json-request-body
+	if r.Body == nil {
 		return *new(T), errors.New("request body is empty")
 	}
 	var v struct {
 		Data *T `json:"data"`
 	}
 	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
 	err := decoder.Decode(&v)
 	if err != nil {
 		return *new(T), err
@@ -122,9 +125,6 @@ type Resp struct {
 	Links    any `json:"links,omitempty"`
 	Meta     any `json:"meta,omitempty"`
 }
-
-// Z is a zero type. Used by [Void].
-type Z = struct{}
 
 // Write response into the connection.
 func (r Resp) Write(w http.ResponseWriter) {

--- a/josh_test.go
+++ b/josh_test.go
@@ -19,9 +19,9 @@ func TestNewServer(t *testing.T) {
 }
 
 func TestSetHeader(t *testing.T) {
-	h := josh.Wrap(func(r josh.Req) josh.Void {
+	h := josh.Wrap(func(r josh.Req) josh.Resp {
 		josh.SetHeader(r, "X-Test", "hello")
-		return josh.NoContent[josh.Z]()
+		return josh.NoContent()
 	})
 	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
 	w := httptest.NewRecorder()
@@ -34,10 +34,10 @@ func TestSetHeader(t *testing.T) {
 
 // It should be possible to unwrap http.ResponseWriter and write the response directly.
 func TestUnwrapResponseWriter(t *testing.T) {
-	h := josh.Wrap(func(r josh.Req) josh.Void {
+	h := josh.Wrap(func(r josh.Req) josh.Resp {
 		w := josh.Must(josh.GetSingleton[http.ResponseWriter](r))
 		w.WriteHeader(204)
-		return josh.Void{}
+		return josh.Resp{}
 	})
 	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
 	w := httptest.NewRecorder()
@@ -61,7 +61,7 @@ func TestUnwrap(t *testing.T) {
 }
 
 func TestRead(t *testing.T) {
-	h := josh.Wrap(func(r josh.Req) josh.Resp[string] {
+	h := josh.Wrap(func(r josh.Req) josh.Resp {
 		msg, err := josh.Read[string](r)
 		if err != nil {
 			panic(err)
@@ -84,7 +84,7 @@ func TestRead(t *testing.T) {
 
 func TestSingleton(t *testing.T) {
 	type User struct{ name string }
-	h := josh.Wrap(func(r josh.Req) josh.Resp[string] {
+	h := josh.Wrap(func(r josh.Req) josh.Resp {
 		var err error
 		_, err = josh.GetSingleton[User](r)
 		if err == nil {
@@ -107,7 +107,7 @@ func TestSingleton(t *testing.T) {
 
 func TestGetOrSetSingleton(t *testing.T) {
 	type User struct{ name string }
-	h := josh.Wrap(func(r josh.Req) josh.Resp[string] {
+	h := josh.Wrap(func(r josh.Req) josh.Resp {
 		r, user := josh.GetOrSetSingleton(r, func() User {
 			return User{"aragorn"}
 		})

--- a/middlewares/auth.go
+++ b/middlewares/auth.go
@@ -16,11 +16,11 @@ type AuthValidator[U any] func(string) (U, error)
 // If the validator returns an error, that erro is immediately returned
 // as an "Unathorized" response. Otherwise, the returned value (typically, the user
 // or their ID) is added into the request context using [josh.WithSingleton].
-func Auth[U, R any](v AuthValidator[U], h josh.Handler[R]) josh.Handler[R] {
-	return func(r josh.Req) josh.Resp[R] {
+func Auth[U any](v AuthValidator[U], h josh.Handler) josh.Handler {
+	return func(r josh.Req) josh.Resp {
 		user, err := validateRequest(v, r)
 		if err != nil {
-			return josh.Unauthorized[R](
+			return josh.Unauthorized(
 				josh.Error{Detail: err.Error()},
 			)
 		}

--- a/middlewares/recover.go
+++ b/middlewares/recover.go
@@ -7,8 +7,8 @@ import (
 )
 
 // Middleware that catches panics, recovers, logs them, and returns 500.
-func Recover[T any](h josh.Handler[T]) josh.Handler[T] {
-	return func(r josh.Req) (resp josh.Resp[T]) {
+func Recover(h josh.Handler) josh.Handler {
+	return func(r josh.Req) (resp josh.Resp) {
 		defer func() {
 			err := recover()
 			if err != nil {
@@ -23,7 +23,7 @@ func Recover[T any](h josh.Handler[T]) josh.Handler[T] {
 					)
 				}
 				errResp := josh.Error{Title: "Internal server error"}
-				resp = josh.InternalServerError[T](errResp)
+				resp = josh.InternalServerError(errResp)
 			}
 		}()
 		return h(r)

--- a/middlewares/recover_test.go
+++ b/middlewares/recover_test.go
@@ -17,7 +17,7 @@ func eq[T comparable](a, b T) {
 }
 
 func TestRecover_Ok(t *testing.T) {
-	hf := func(r josh.Req) josh.Resp[string] {
+	hf := func(r josh.Req) josh.Resp {
 		return josh.Ok("hi")
 	}
 	h := josh.Wrap(middlewares.Recover(hf))
@@ -31,7 +31,7 @@ func TestRecover_Ok(t *testing.T) {
 }
 
 func TestRecover_Panic(t *testing.T) {
-	hf := func(r josh.Req) josh.Resp[string] {
+	hf := func(r josh.Req) josh.Resp {
 		panic("oh no")
 	}
 	h := josh.Wrap(middlewares.Recover(hf))

--- a/middlewares/with.go
+++ b/middlewares/with.go
@@ -5,16 +5,16 @@ import (
 )
 
 // With is a middleware that adds the given value into request context using [josh.WithSingleton].
-func With[D, R any](data D, h josh.Handler[R]) josh.Handler[R] {
-	return func(r josh.Req) (resp josh.Resp[R]) {
+func With[D any](data D, h josh.Handler) josh.Handler {
+	return func(r josh.Req) (resp josh.Resp) {
 		r = josh.Must(josh.WithSingleton(r, data))
 		return h(r)
 	}
 }
 
 // With2 is like [With] but sets 2 values in one go.
-func With2[A, B, R any](a A, b B, h josh.Handler[R]) josh.Handler[R] {
-	return func(r josh.Req) (resp josh.Resp[R]) {
+func With2[A, B any](a A, b B, h josh.Handler) josh.Handler {
+	return func(r josh.Req) (resp josh.Resp) {
 		r = josh.Must(josh.WithSingleton(r, a))
 		r = josh.Must(josh.WithSingleton(r, b))
 		return h(r)
@@ -22,8 +22,8 @@ func With2[A, B, R any](a A, b B, h josh.Handler[R]) josh.Handler[R] {
 }
 
 // With3 is like [With] but sets 3 values in one go.
-func With3[A, B, C, R any](a A, b B, c C, h josh.Handler[R]) josh.Handler[R] {
-	return func(r josh.Req) (resp josh.Resp[R]) {
+func With3[A, B, C any](a A, b B, c C, h josh.Handler) josh.Handler {
+	return func(r josh.Req) (resp josh.Resp) {
 		r = josh.Must(josh.WithSingleton(r, a))
 		r = josh.Must(josh.WithSingleton(r, b))
 		r = josh.Must(josh.WithSingleton(r, c))
@@ -32,8 +32,8 @@ func With3[A, B, C, R any](a A, b B, c C, h josh.Handler[R]) josh.Handler[R] {
 }
 
 // With4 is like [With] but sets 4 values in one go.
-func With4[A, B, C, D, R any](a A, b B, c C, d D, h josh.Handler[R]) josh.Handler[R] {
-	return func(r josh.Req) (resp josh.Resp[R]) {
+func With4[A, B, C, D any](a A, b B, c C, d D, h josh.Handler) josh.Handler {
+	return func(r josh.Req) (resp josh.Resp) {
 		r = josh.Must(josh.WithSingleton(r, a))
 		r = josh.Must(josh.WithSingleton(r, b))
 		r = josh.Must(josh.WithSingleton(r, c))
@@ -43,13 +43,26 @@ func With4[A, B, C, D, R any](a A, b B, c C, d D, h josh.Handler[R]) josh.Handle
 }
 
 // With5 is like [With] but sets 5 values in one go.
-func With5[A, B, C, D, E, R any](a A, b B, c C, d D, e E, h josh.Handler[R]) josh.Handler[R] {
-	return func(r josh.Req) (resp josh.Resp[R]) {
+func With5[A, B, C, D, E any](a A, b B, c C, d D, e E, h josh.Handler) josh.Handler {
+	return func(r josh.Req) (resp josh.Resp) {
 		r = josh.Must(josh.WithSingleton(r, a))
 		r = josh.Must(josh.WithSingleton(r, b))
 		r = josh.Must(josh.WithSingleton(r, c))
 		r = josh.Must(josh.WithSingleton(r, d))
 		r = josh.Must(josh.WithSingleton(r, e))
+		return h(r)
+	}
+}
+
+// With5 is like [With] but sets 6 values in one go.
+func With6[A, B, C, D, E, F any](a A, b B, c C, d D, e E, f F, h josh.Handler) josh.Handler {
+	return func(r josh.Req) (resp josh.Resp) {
+		r = josh.Must(josh.WithSingleton(r, a))
+		r = josh.Must(josh.WithSingleton(r, b))
+		r = josh.Must(josh.WithSingleton(r, c))
+		r = josh.Must(josh.WithSingleton(r, d))
+		r = josh.Must(josh.WithSingleton(r, e))
+		r = josh.Must(josh.WithSingleton(r, f))
 		return h(r)
 	}
 }

--- a/path_test.go
+++ b/path_test.go
@@ -9,10 +9,10 @@ import (
 )
 
 func TestGetID(t *testing.T) {
-	h := josh.Wrap(func(r josh.Req) josh.Resp[int] {
+	h := josh.Wrap(func(r josh.Req) josh.Resp {
 		id, errResp := josh.GetID[int](r, "id")
 		if errResp != nil {
-			return josh.BadRequest[int](*errResp)
+			return josh.BadRequest(*errResp)
 		}
 		return josh.Ok(id)
 	})

--- a/router_test.go
+++ b/router_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/orsinium-labs/josh"
 )
 
-func noop(*http.Request) josh.Void {
-	return josh.NoContent[josh.Z]()
+func noop(*http.Request) josh.Resp {
+	return josh.NoContent()
 }
 
 func must[T any](v T, err error) T {


### PR DESCRIPTION
Generic Handler and Resp add lots of complexity (because Go type inference for generics is quite basic) and doesn't add enough benefits to keep it. A typical Handler returns only one Ok response and multiple Error responses.